### PR TITLE
Feat : setting 클래스, setting menu factory 추가

### DIFF
--- a/app/src/main/java/org/tetris/menu/setting/SettingMenuFactory.java
+++ b/app/src/main/java/org/tetris/menu/setting/SettingMenuFactory.java
@@ -1,0 +1,11 @@
+package org.tetris.menu.setting;
+
+import org.tetris.menu.setting.controller.SettingMenuController;
+import org.tetris.menu.setting.model.SettingMenuModel;
+import org.tetris.shared.MvcFactory;
+
+public class SettingMenuFactory extends MvcFactory<SettingMenuModel, SettingMenuController> {
+    public SettingMenuFactory(Setting setting) {
+        super(() -> new SettingMenuModel(setting), model -> new SettingMenuController(model), "view/settingmenu.fxml");
+    }
+}

--- a/app/src/main/java/org/tetris/menu/setting/model/Setting.java
+++ b/app/src/main/java/org/tetris/menu/setting/model/Setting.java
@@ -1,0 +1,144 @@
+package org.tetris.menu.setting;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.Properties;
+
+import org.util.Difficulty;
+import org.util.GameColor;
+import org.util.KeyLayout;
+import org.util.ScreenPreset;
+
+import javafx.scene.input.KeyCode;
+
+public class Setting {
+    private static final String DEFAULT_FILE_NAME = "setting.txt";
+    private static final String KEY_COLOR_BLIND = "isColorBlind";
+    private static final String KEY_KEY_LAYOUT = "keyLayout"; // ARROWS | WASD
+    private static final String KEY_SCREEN = "screen"; // SMALL | MIDDLE | LARGE
+    private static final String KEY_DIFFICULTY = "difficulty"; // EASY | NORMAL | HARD
+
+    private final Path filePath;
+    private final Properties props = new Properties();
+
+    /* --------- 생성/로딩 --------- */
+
+    // 기본 생성자: 기본 파일명 사용 (싱글 플레이어)
+    public Setting() {
+        filePath = Paths.get(DEFAULT_FILE_NAME);
+        loadOrInit();
+    }
+
+    /* --------- Getter --------- */
+
+    public boolean isColorBlind() {
+        return Boolean.parseBoolean(props.getProperty(KEY_COLOR_BLIND, "false"));
+    }
+
+    public String getKeyLayout() {
+        return props.getProperty(KEY_KEY_LAYOUT, "ARROWS");
+    }
+
+    public String getScreenPreset() {
+        return props.getProperty(KEY_SCREEN, "SMALL");
+    }
+
+    public String getDifficulty() {
+        return props.getProperty(KEY_DIFFICULTY, "EASY");
+    }
+
+    /* --------- Setter (저장 포함) --------- */
+
+    public void setColorBlind(boolean value) {
+        props.setProperty(KEY_COLOR_BLIND, Boolean.toString(value));
+        saveSettingFile();
+    }
+
+    public void setKeyLayout(String layout) {
+        if (layout == null)
+            layout = "ARROWS";
+        props.setProperty(KEY_KEY_LAYOUT, layout);
+        saveSettingFile();
+    }
+
+    public void setScreenPreset(String preset) {
+        if (preset == null)
+            preset = "SMALL";
+        props.setProperty(KEY_SCREEN, preset);
+        saveSettingFile();
+    }
+
+    public void setDifficulty(String difficulty) {
+        if (difficulty == null)
+            difficulty = "EASY";
+        props.setProperty(KEY_DIFFICULTY, difficulty);
+        saveSettingFile();
+    }
+
+    /* --------- 내부 유틸 --------- */
+
+    private void loadOrInit() {
+        if (Files.exists(filePath)) {
+            try (InputStream in = Files.newInputStream(filePath)) {
+                props.load(in);
+            } catch (IOException e) {
+                setDefaultsAndSave();
+                return;
+            }
+            // 누락 키 보완
+            props.putIfAbsent(KEY_COLOR_BLIND, "false");
+            props.putIfAbsent(KEY_KEY_LAYOUT, "ARROWS");
+            props.putIfAbsent(KEY_SCREEN, "SMALL");
+            props.putIfAbsent(KEY_DIFFICULTY, "EASY");
+
+            saveSettingFile(); // 보완된 기본값/매핑을 반영
+        } else {
+            setDefaultsAndSave();
+        }
+    }
+
+    public void setDefaultsAndSave() {
+        props.clear();
+        props.setProperty(KEY_COLOR_BLIND, "false");
+        props.setProperty(KEY_KEY_LAYOUT, "ARROWS");
+        props.setProperty(KEY_SCREEN, "SMALL");
+        props.setProperty(KEY_DIFFICULTY, "EASY");
+
+        saveSettingFile();
+    }
+
+    private void saveSettingFile() {
+        try (OutputStream out = Files.newOutputStream(
+                filePath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            props.store(out, "Tetris Settings");
+            syncAllSettings();
+        } catch (IOException e) {
+            System.err.println("[Setting] 저장 실패: " + e.getMessage());
+        }
+    }
+
+    /* --------- Sync 메서드들 --------- */
+
+    private void syncAllSettings() {
+        syncGameColor();
+        syncKeyLayout();
+        syncScreenPreset();
+        syncDifficulty();
+    }
+
+    private void syncGameColor() {
+        GameColor.setColorBlind(isColorBlind());
+    }
+
+    private void syncKeyLayout() {
+        KeyLayout.setCurrentLayout(getKeyLayout());
+    }
+
+    private void syncScreenPreset() {
+        ScreenPreset.setCurrentPreset(getScreenPreset());
+    }
+
+    private void syncDifficulty() {
+        Difficulty.setCurrentDifficulty(getDifficulty());
+    }
+}

--- a/app/src/main/java/org/tetris/menu/setting/model/SettingMenu.java
+++ b/app/src/main/java/org/tetris/menu/setting/model/SettingMenu.java
@@ -1,2 +1,0 @@
-package org.tetris.menu.setting.model;
-

--- a/app/src/test/java/org/tetris/menu/setting/model/SettingTest.java
+++ b/app/src/test/java/org/tetris/menu/setting/model/SettingTest.java
@@ -1,0 +1,145 @@
+package org.tetris.menu.setting;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+    
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.util.Difficulty;
+import org.util.GameColor;
+import org.util.KeyLayout;
+import org.util.ScreenPreset;
+
+public class SettingTest {
+    
+    private Setting setting;
+    private final Path testFilePath = Paths.get("setting.txt");
+    
+    @Before
+    public void setUp() {
+        // 테스트 전에 기존 설정 파일 삭제
+        deleteSettingFile();
+        setting = new Setting();
+    }
+    
+    @After
+    public void tearDown() {
+        // 테스트 후 설정 파일 삭제
+        deleteSettingFile();
+    }
+    
+    private void deleteSettingFile() {
+        try {
+            Files.deleteIfExists(testFilePath);
+        } catch (IOException e) {
+            // 무시
+        }
+    }
+    
+    @Test
+    public void testDefaultValues() {
+        assertEquals("기본 색맹 모드는 false여야 합니다", false, setting.isColorBlind());
+        assertEquals("기본 키 레이아웃은 ARROWS여야 합니다", "ARROWS", setting.getKeyLayout());
+        assertEquals("기본 화면 프리셋은 SMALL이어야 합니다", "SMALL", setting.getScreenPreset());
+        assertEquals("기본 난이도는 EASY여야 합니다", "EASY", setting.getDifficulty());
+    }
+    
+    @Test
+    public void testSetColorBlind() {
+        setting.setColorBlind(true);
+        assertTrue("색맹 모드가 true로 설정되어야 합니다", setting.isColorBlind());
+        assertTrue("GameColor의 색맹 모드도 동기화되어야 합니다", 
+                  GameColor.getColorBlind());
+        
+        setting.setColorBlind(false);
+        assertFalse("색맹 모드가 false로 설정되어야 합니다", setting.isColorBlind());
+        assertFalse("GameColor의 색맹 모드도 동기화되어야 합니다", 
+                   GameColor.getColorBlind());
+    }
+    
+    @Test
+    public void testSetKeyLayout() {
+        setting.setKeyLayout("WASD");
+        assertEquals("키 레이아웃이 WASD로 설정되어야 합니다", "WASD", setting.getKeyLayout());
+        assertEquals("KeyLayout의 현재 레이아웃도 동기화되어야 합니다", 
+                    "WASD", KeyLayout.getCurrentLayout());
+        
+        setting.setKeyLayout("ARROWS");
+        assertEquals("키 레이아웃이 ARROWS로 설정되어야 합니다", "ARROWS", setting.getKeyLayout());
+        assertEquals("KeyLayout의 현재 레이아웃도 동기화되어야 합니다", 
+                    "ARROWS", KeyLayout.getCurrentLayout());
+    }
+    
+    @Test
+    public void testSetScreenPreset() {
+        setting.setScreenPreset("MIDDLE");
+        assertEquals("화면 프리셋이 MIDDLE로 설정되어야 합니다", "MIDDLE", setting.getScreenPreset());
+        assertEquals("ScreenPreset의 현재 프리셋도 동기화되어야 합니다", 
+                    "MIDDLE", ScreenPreset.getCurrentPreset());
+        
+        setting.setScreenPreset("LARGE");
+        assertEquals("화면 프리셋이 LARGE로 설정되어야 합니다", "LARGE", setting.getScreenPreset());
+        assertEquals("ScreenPreset의 현재 프리셋도 동기화되어야 합니다", 
+                    "LARGE", ScreenPreset.getCurrentPreset());
+    }
+    
+    @Test
+    public void testSetDifficulty() {
+        setting.setDifficulty("NORMAL");
+        assertEquals("난이도가 NORMAL로 설정되어야 합니다", "NORMAL", setting.getDifficulty());
+        assertEquals("Difficulty의 현재 난이도도 동기화되어야 합니다", 
+                    "NORMAL", Difficulty.getCurrentDifficulty());
+        
+        setting.setDifficulty("HARD");
+        assertEquals("난이도가 HARD로 설정되어야 합니다", "HARD", setting.getDifficulty());
+        assertEquals("Difficulty의 현재 난이도도 동기화되어야 합니다", 
+                    "HARD", Difficulty.getCurrentDifficulty());
+    }
+    
+    @Test
+    public void testSetDefaultsAndSave() {
+        // 먼저 값을 변경
+        setting.setColorBlind(true);
+        setting.setKeyLayout("WASD");
+        setting.setScreenPreset("LARGE");
+        setting.setDifficulty("HARD");
+        
+        // 기본값으로 초기화
+        setting.setDefaultsAndSave();
+        
+        assertEquals("기본값으로 초기화 후 색맹 모드는 false여야 합니다", 
+                    false, setting.isColorBlind());
+        assertEquals("기본값으로 초기화 후 키 레이아웃은 ARROWS여야 합니다", 
+                    "ARROWS", setting.getKeyLayout());
+        assertEquals("기본값으로 초기화 후 화면 프리셋은 SMALL이어야 합니다", 
+                    "SMALL", setting.getScreenPreset());
+        assertEquals("기본값으로 초기화 후 난이도는 EASY여야 합니다", 
+                    "EASY", setting.getDifficulty());
+    }
+    
+    @Test
+    public void testSettingFilePersistence() {
+        // 설정 변경
+        setting.setColorBlind(true);
+        setting.setKeyLayout("WASD");
+        setting.setScreenPreset("MIDDLE");
+        setting.setDifficulty("NORMAL");
+        
+        // 새로운 Setting 객체 생성 (파일에서 로드)
+        Setting newSetting = new Setting();
+        
+        assertEquals("파일에서 로드된 색맹 모드가 일치해야 합니다", 
+                    true, newSetting.isColorBlind());
+        assertEquals("파일에서 로드된 키 레이아웃이 일치해야 합니다", 
+                    "WASD", newSetting.getKeyLayout());
+        assertEquals("파일에서 로드된 화면 프리셋이 일치해야 합니다", 
+                    "MIDDLE", newSetting.getScreenPreset());
+        assertEquals("파일에서 로드된 난이도가 일치해야 합니다", 
+                    "NORMAL", newSetting.getDifficulty());
+    }
+}


### PR DESCRIPTION
## 🔀 개요
#32  수정 router 제외

## 💡 변경 사항

- [ ] 주요 기능 추가/변경

> 난이도, 키보드 인풋, 스크린 사이즈, 색맹을 저장하고 로드하는 setting 클래스 구현
> setting factory 추가

## 🧪 테스트 방법

- SettingTest 파일 생성. 해당 파일만 테스트 통과 확인했음

## ⚠️ 주의사항 / 리뷰 포인트

- 중점적으로 봐줬으면 하는 부분이나 논의가 필요한 부분이 있다면 명시해주세요.

## 📎 기타 참고

- 관련 문서, 스크린샷, 디자인 링크 등 추가 정보가 있다면 첨부해주세요.
