### PR TITLE
fix: resume 메서드 버그 픽스

### DIFF
--- a/app/src/main/java/org/tetris/game/controller/GameController.java
+++ b/app/src/main/java/org/tetris/game/controller/GameController.java
@@ -492,6 +492,15 @@ public class GameController extends BaseController<GameModel> implements RouterA
     private void resumeGame() {
         gameModel.setPaused(false);
         hidePauseOverlay();
+
+        if (gameLoop != null) {
+            lastUpdate = 0;
+            lastDropTime = 0;
+            gameLoop.start();
+        } else {
+            startGameLoop();
+        }
+        root.requestFocus();
     }
     
     private void goToMenuFromPause() {


### PR DESCRIPTION
## 🔀 개요

- 메인메뉴로 갔다가 다시 게임으로 돌아가서 resume하면 블럭이 안내려가던 버그 수정.

## 💡 변경 사항

- GameController의 resumeGame()만 변경.
- 메인 메뉴로 나갔다가 게임으로 돌아오면 gameLoop가 재시작하지 않는 문제를 해결
- gameLoop가 기존 게 있다면 그것을 재실행
- 없으면 새로 시작.

## 테스트
- 테스트 함수를 만드는 것은 어려울 것 같아 구현하지 않았습니다
